### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [source]
 
+permissions:
+  contents: read
+  pages: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/0xmfbk/0xmfbk.github.io/security/code-scanning/1](https://github.com/0xmfbk/0xmfbk.github.io/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow deploys content to GitHub Pages, it likely requires `contents: read` to access the repository files and `pages: write` to publish the content. The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build-and-deploy`) to limit permissions for that job only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
